### PR TITLE
opentelemetry-instrumentation-urllib3 0.59b0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-urllib3" %}
-{% set version = "0.58b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 978b8e3daa076437b1f7ed7509d8156108aee0679556fd355e532c4065dd7635
+  sha256: 2de8d53a746bba043be1bc8f3246e1b131ebb6e94fe73601edd8b2bd91fe35b8
 
 build:
   number: 0
@@ -16,8 +16,8 @@ build:
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - hatchling
   run:
     - python


### PR DESCRIPTION
opentelemetry-instrumentation-urllib3 0.59b0 

**Destination channel:** Defaults

### Links

- [PKG-11138]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python-contrib/tree/v0.59b0
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-urllib3-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-urllib3/0.59b0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-urllib3/0.59b0

### Explanation of changes:

- new version number


[PKG-11138]: https://anaconda.atlassian.net/browse/PKG-11138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ